### PR TITLE
changes to build/release scripts

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,13 +32,13 @@ jobs:
         run: ./build/install_docker.sh
 
       - name: go build, docker build
-        run: ./build/build.sh $GITHUB_SHA
+        run: VERSION=$GITHUB_SHA ./build/build.sh
 
       - name: Install kubectl, helm, kind
         run: ./test/e2e/install_dependencies.sh
 
       - name: End-to-end test
-        run: ./test/e2e/e2e.sh $GITHUB_SHA
+        run: VERSION=$GITHUB_SHA ./test/e2e/e2e.sh
 
       - name: Archive cluster dump
         if: ${{ failure() }}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,0 @@
-FROM scratch
-ARG target
-COPY ${target}/manager .
-ENTRYPOINT ["./manager"]

--- a/build/build_one.sh
+++ b/build/build_one.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Copyright 2020 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+# constants
+DEFAULT_BIN_PREFIX=multicluster-scheduler-
+
+# environment variables
+# required
+PKG="${PKG}"
+# optional
+BIN="${BIN:-$DEFAULT_BIN_PREFIX$(basename "$PKG")}"
+OS="${OS:-linux}"
+ARCH="${ARCH:-amd64}"
+BUILD_IMG="${BUILD_IMG:-true}"
+IMG="${IMG:-$BIN}"
+BASE_IMG="${BASE_IMG:-scratch}"
+VERSION="${VERSION:-dev}"
+LDFLAGS="${LDFLAGS:-}"
+DEBUG="${DEBUG:-false}"
+
+extra_args=()
+if [ -n "$LDFLAGS" ]; then
+  extra_args+=("-ldflags" "$LDFLAGS")
+fi
+if [ "$DEBUG" = true ]; then
+  extra_args+=("-gcflags=all=-N -l")
+fi
+
+context_dir="_out/$PKG/run/$OS/$ARCH"
+if [ "$DEBUG" = true ]; then
+  context_dir="_out/$PKG/debug/$OS/$ARCH"
+fi
+
+mkdir -p "$context_dir"
+
+CGO_ENABLED=0 GOOS=$OS GOARCH=$ARCH go build -trimpath -o "$context_dir/$BIN" "${extra_args[@]}" "$PKG"
+if [ "$VERSION" != dev ] && [ "$ARCH" != s390x ]; then
+  upx-ucl "$context_dir/$BIN"
+fi
+
+if [ "$BUILD_IMG" = true ]; then
+  if [ "$DEBUG" = true ]; then
+    cp "$(command -v dlv)" "$context_dir" # `command -v` is the portable version of `which`
+    cat <<EOF >"$context_dir/Dockerfile"
+FROM $BASE_IMG
+COPY dlv /usr/local/bin/dlv
+COPY $BIN /usr/local/bin/$BIN
+ENTRYPOINT ["dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "--continue", "/usr/local/bin/$BIN", "--"]
+EOF
+  else
+    cat <<EOF >"$context_dir/Dockerfile"
+FROM $BASE_IMG
+COPY $BIN /usr/local/bin/$BIN
+ENTRYPOINT ["$BIN"]
+EOF
+  fi
+
+  cat "$context_dir"/Dockerfile
+
+  docker build -t "$IMG:$VERSION-$ARCH" "$context_dir"
+fi

--- a/build/install_docker.sh
+++ b/build/install_docker.sh
@@ -1,3 +1,19 @@
+#
+# Copyright 2020 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -euo pipefail
 
 # from https://docs.docker.com/engine/install/ubuntu/
@@ -18,3 +34,5 @@ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubun
 sudo apt-get update
 
 sudo apt-get install docker-ce docker-ce-cli containerd.io
+
+sudo apt-get install upx-ucl

--- a/pipeline.sh
+++ b/pipeline.sh
@@ -1,16 +1,30 @@
 #!/usr/bin/env bash
-set -euo pipefail
+#
+# Copyright 2020 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-VERSION="$1"
+set -euo pipefail
 
 echo "test"
 test/test.sh
 echo "build"
-build/build.sh "$VERSION"
+build/build.sh
 echo "e2e test"
-test/e2e/e2e.sh "$VERSION"
+test/e2e/e2e.sh
 echo "release images"
-release/images.sh "$VERSION"
+release/images.sh
 echo "release chart"
 release/chart.sh
 # TODO: create release on GitHub

--- a/release/chart.sh
+++ b/release/chart.sh
@@ -1,11 +1,26 @@
 #!/usr/bin/env bash
+#
+# Copyright 2020 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -euo pipefail
 
 helm package charts/multicluster-scheduler -d _out
-cp charts/index.yaml _out/
-helm repo index _out --merge _out/index.yaml --url https://charts.admiralty.io
+helm repo index _out --merge <(curl -s https://charts.admiralty.io/index.yaml) --url https://charts.admiralty.io
 
 # release CRDs separately, esp. for `helm upgrade`
-cat charts/multicluster-scheduler/crds/* > _out/admiralty.crds.yaml
+cat charts/multicluster-scheduler/crds/* >_out/admiralty.crds.yaml
 
 # TODO: upload Helm chart and new index

--- a/release/images.sh
+++ b/release/images.sh
@@ -17,20 +17,13 @@
 
 set -euo pipefail
 
-DEFAULT_REGISTRY="quay.io/admiralty"
-
-VERSION="$1"
-REGISTRY="${2:-$DEFAULT_REGISTRY}"
-
-CMDS=(
-  "agent"
-  "remove-finalizers"
-  "scheduler"
-  "restarter"
+imgs=(
+  multicluster-scheduler-agent
+  multicluster-scheduler-remove-finalizers
+  multicluster-scheduler-scheduler
+  multicluster-scheduler-restarter
 )
 
-for CMD in "${CMDS[@]}"; do
-  IMG="multicluster-scheduler-$CMD"
-  docker tag "$DEFAULT_REGISTRY/$IMG:$VERSION" "$REGISTRY/$IMG:$VERSION"
-  docker push "$REGISTRY/$IMG:$VERSION"
+for img in "${imgs[@]}"; do
+  IMG="$img" ARCHS="amd64 arm64 ppc64le s390x" ./release/image.sh
 done

--- a/test/e2e/admiralty.sh
+++ b/test/e2e/admiralty.sh
@@ -1,5 +1,23 @@
 #!/usr/bin/env bash
+#
+# Copyright 2020 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -euo pipefail
+
+VERSION="${VERSION:-dev}"
 
 source test/e2e/aliases.sh
 source test/e2e/kind.sh
@@ -8,21 +26,24 @@ source test/e2e/webhook_ready.sh
 admiralty_setup() {
   i=$1
   VALUES=$2
-  VERSION="$3"
 
-  kind load docker-image quay.io/admiralty/multicluster-scheduler-agent:$VERSION --name cluster$i
-  kind load docker-image quay.io/admiralty/multicluster-scheduler-scheduler:$VERSION --name cluster$i
-  kind load docker-image quay.io/admiralty/multicluster-scheduler-remove-finalizers:$VERSION --name cluster$i
-  kind load docker-image quay.io/admiralty/multicluster-scheduler-restarter:$VERSION --name cluster$i
+  kind load docker-image multicluster-scheduler-agent:$VERSION-amd64 --name cluster$i
+  kind load docker-image multicluster-scheduler-scheduler:$VERSION-amd64 --name cluster$i
+  kind load docker-image multicluster-scheduler-remove-finalizers:$VERSION-amd64 --name cluster$i
+  kind load docker-image multicluster-scheduler-restarter:$VERSION-amd64 --name cluster$i
 
   if ! k $i get ns admiralty; then
     k $i create namespace admiralty
   fi
   h $i upgrade --install multicluster-scheduler charts/multicluster-scheduler -n admiralty -f $VALUES \
-    --set controllerManager.image.tag=$VERSION \
-    --set scheduler.image.tag=$VERSION \
-    --set postDeleteJob.image.tag=$VERSION \
-    --set restarter.image.tag=$VERSION
+    --set controllerManager.image.repository=multicluster-scheduler-agent \
+    --set scheduler.image.repository=multicluster-scheduler-scheduler \
+    --set postDeleteJob.image.repository=multicluster-scheduler-remove-finalizers \
+    --set restarter.image.repository=multicluster-scheduler-restarter \
+    --set controllerManager.image.tag=$VERSION-amd64 \
+    --set scheduler.image.tag=$VERSION-amd64 \
+    --set postDeleteJob.image.tag=$VERSION-amd64 \
+    --set restarter.image.tag=$VERSION-amd64
   k $i delete pod --all -n admiralty
 
   k $i label ns default multicluster-scheduler=enabled --overwrite

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -17,8 +17,6 @@
 
 set -euo pipefail
 
-VERSION="$1"
-
 source test/e2e/aliases.sh
 source test/e2e/admiralty.sh
 source test/e2e/argo.sh
@@ -35,7 +33,7 @@ cert_manager_setup_once
 for i in 1 2; do
   kind_setup $i
   cert_manager_setup $i
-  admiralty_setup $i test/e2e/values.yaml $VERSION
+  admiralty_setup $i test/e2e/values.yaml
 done
 
 k 2 apply -f test/e2e/topologies/namespaced-burst/cluster2/source.yaml


### PR DESCRIPTION
- refactor single build/release into separate scripts
- build for multiple architectures (except in dev/CI) and push multi-arch manifests (amd64, arm64, ppc64le, and s390x, per requests from users, fix #27)
- compress binaries with UPX (except for s390x which isn't supported by UPX)
- build debug images (TODO: wire up in Helm chart)

Signed-off-by: adrienjt <adrienjt@users.noreply.github.com>