### PR TITLE
no-reservation annotation to work without candidate scheduler

### DIFF
--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -29,6 +29,13 @@ var (
 
 	AnnotationKeyElect = KeyPrefix + "elect"
 
+	// AnnotationKeyNoReservation tells the proxy scheduler to work with a custom scheduler in the target cluster,
+	// instead of the candidate scheduler, waiting for candidate pods to be scheduled, instead of reserved,
+	// to pass the proxy plugin filter test. Pods deleted in the post-bind plugin (those that didn't pass the score test)
+	// may be scheduled already, not just pending. That is an acceptable compromise to work with a custom scheduler.
+	// TODO: an alternative option would be to schedule based on virtual node info only (like tensile-kube).
+	AnnotationKeyNoReservation = KeyPrefix + "no-reservation"
+
 	// annotations on proxy pods (by mutating admission webhook)
 
 	KeyPrefixSourcePod = KeyPrefix + "sourcepod-"

--- a/pkg/model/delegatepod/model.go
+++ b/pkg/model/delegatepod/model.go
@@ -67,7 +67,9 @@ func MakeDelegatePod(proxyPod *corev1.Pod) (*v1alpha1.PodChaperon, error) {
 	// (for forward compatibility and we've certainly forgotten incompatible fields...)
 	// TODO... maybe make this configurable, sort of like Federation v2 Overrides
 
-	delegatePod.Spec.SchedulerName = common.CandidateSchedulerName
+	if _, ok := srcPod.Annotations[common.AnnotationKeyNoReservation]; !ok {
+		delegatePod.Spec.SchedulerName = common.CandidateSchedulerName
+	}
 
 	return delegatePod, nil
 }


### PR DESCRIPTION
filter virtual nodes over multiple scheduling cycles

fix #82 

Signed-off-by: adrienjt <adrienjt@users.noreply.github.com>