### PR TITLE
e2e test for k8s versions 1.17 through 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -48,10 +48,15 @@ jobs:
     name: End-to-end test
     needs: build
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
       fail-fast: false
       matrix:
-        k8s_version: [ "1.17", "1.18", "1.19", "1.20", "1.21", "1.22" ]
+        k8s_version: [ "1.17", "1.18", "1.19", "1.20", "1.21" ]
+        experimental: [ false ]
+        include:
+          - k8s_version: "1.22"
+            experimental: true
     steps:
 
       - name: Check out code into the Go module directory

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   build:
-    name: All
+    name: Verify code gen, vet, unit test, build, and build images
     runs-on: ubuntu-latest
     steps:
 
@@ -36,17 +36,49 @@ jobs:
         run: ./build/install_docker.sh
 
       - name: go build, docker build
-        run: VERSION=$GITHUB_SHA ./build/build.sh
+        run: VERSION=$GITHUB_SHA OUTPUT_TAR_GZ=true ./build/build.sh
+
+      - name: Upload images as artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: images
+          path: images
+
+  e2e:
+    name: End-to-end test
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        k8s_version: [ "1.17", "1.18", "1.19", "1.20", "1.21", "1.22" ]
+    steps:
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Install Docker
+        run: ./build/install_docker.sh
+
+      - name: Download image artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: images
+          path: images
+
+      - name: docker load
+        run: |
+          ./build/load.sh
 
       - name: Install kubectl, helm, kind
         run: ./test/e2e/install_dependencies.sh
 
       - name: End-to-end test
-        run: VERSION=$GITHUB_SHA ./test/e2e/e2e.sh
+        run: VERSION=$GITHUB_SHA K8S_VERSION=${{ matrix.k8s_version }} ./test/e2e/e2e.sh
 
       - name: Archive cluster dump
         if: ${{ failure() }}
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@v2
         with:
           name: cluster-dump
           path: cluster-dump

--- a/build/build_one.sh
+++ b/build/build_one.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Copyright 2020 The Multicluster-Scheduler Authors.
+# Copyright 2021 The Multicluster-Scheduler Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ BASE_IMG="${BASE_IMG:-scratch}"
 VERSION="${VERSION:-dev}"
 LDFLAGS="${LDFLAGS:-}"
 DEBUG="${DEBUG:-false}"
+OUTPUT_TAR_GZ="${OUTPUT_TAR_GZ:-false}"
 
 extra_args=()
 if [ -n "$LDFLAGS" ]; then
@@ -74,4 +75,8 @@ EOF
   cat "$context_dir"/Dockerfile
 
   docker build -t "$IMG:$VERSION-$ARCH" "$context_dir"
+  if [ "$OUTPUT_TAR_GZ" = true ]; then
+    mkdir -p images
+    docker save "$IMG:$VERSION-$ARCH" | gzip > images/"$IMG"_"$VERSION-$ARCH".tar.gz
+  fi
 fi

--- a/build/load.sh
+++ b/build/load.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+for img_tar in images/*.tar.gz; do
+  docker load -i $img_tar
+done

--- a/charts/multicluster-scheduler/templates/deploy.yaml
+++ b/charts/multicluster-scheduler/templates/deploy.yaml
@@ -72,7 +72,7 @@ spec:
         {{- end }}
 ---
 {{- if gt .Values.controllerManager.replicas 1 }}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-controller-manager
@@ -138,7 +138,7 @@ spec:
         {{- end }}
 ---
 {{- if gt .Values.scheduler.replicas 1 }}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-proxy-scheduler
@@ -204,7 +204,7 @@ spec:
         {{- end }}
 ---
 {{- if gt .Values.scheduler.replicas 1 }}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-candidate-scheduler
@@ -274,7 +274,7 @@ spec:
         {{- end }}
 ---
 {{- if gt .Values.restarter.replicas 1 }}
-apiVersion: policy/v1
+apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-restarter

--- a/test/e2e/kind.sh
+++ b/test/e2e/kind.sh
@@ -1,7 +1,39 @@
 #!/usr/bin/env bash
+#
+# Copyright 2021 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 set -euo pipefail
 
 source test/e2e/aliases.sh
+
+# images built for kind v0.11.1
+# https://github.com/kubernetes-sigs/kind/releases/tag/v0.11.1
+declare -A kind_images
+kind_images[1.21]="kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6"
+kind_images[1.20]="kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9"
+kind_images[1.19]="kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729"
+kind_images[1.18]="kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c"
+kind_images[1.17]="kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00"
+kind_images[1.16]="kindest/node:v1.16.15@sha256:83067ed51bf2a3395b24687094e283a7c7c865ccc12a8b1d7aa673ba0c5e8861"
+kind_images[1.15]="kindest/node:v1.15.12@sha256:b920920e1eda689d9936dfcf7332701e80be12566999152626b2c9d730397a95"
+kind_images[1.14]="kindest/node:v1.14.10@sha256:f8a66ef82822ab4f7569e91a5bccaf27bceee135c1457c512e54de8c6f7219f8"
+# "known to work well" (k8s 1.22 wasn't released when kind 0.11.1 was released)
+kind_images[1.22]="kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047"
+
+K8S_VERSION="${K8S_VERSION:-"1.21"}"
 
 kind_setup() {
   i=$1
@@ -9,7 +41,7 @@ kind_setup() {
   CLUSTER=cluster$i
 
   if ! kind get clusters | grep $CLUSTER; then
-    kind create cluster --name $CLUSTER --wait 5m
+    kind create cluster --name $CLUSTER --wait 5m --image "${kind_images["$K8S_VERSION"]}"
   fi
   NODE_IP=$(docker inspect "${CLUSTER}-control-plane" --format "{{ .NetworkSettings.Networks.kind.IPAddress }}")
   kind get kubeconfig --name $CLUSTER --internal | \


### PR DESCRIPTION
Split the current single multi-step GitHub Actions job into two, so a matrix of e2e test jobs can run in parallel after the build job runs once.

Pick kind node image based on K8S_VERSION environment variable.