### PR TITLE
disable e2e test for k8s 1.22 for now

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -54,9 +54,14 @@ jobs:
       matrix:
         k8s_version: [ "1.17", "1.18", "1.19", "1.20", "1.21" ]
         experimental: [ false ]
-        include:
-          - k8s_version: "1.22"
-            experimental: true
+        # workflow succeeds even if experimental job fails,
+        # but commit/PR check/status still appears as failure overall,
+        # so 1.22 job is commented out for now, cf.
+        # - https://github.community/t/continue-on-error-allow-failure-ui-indication/16773/14
+        # - https://github.com/actions/toolkit/issues/399
+    #        include:
+    #          - k8s_version: "1.22"
+    #            experimental: true
     steps:
 
       - name: Check out code into the Go module directory


### PR DESCRIPTION
Although we use continue-on-error (GitHub Actions job setting) for 1.22, and the workflow does succeed even if the job fails, PR and commit checks appear failing, which isn't our intention:

- https://github.community/t/continue-on-error-allow-failure-ui-indication/16773/14
- https://github.com/actions/toolkit/issues/399