### PR TITLE
Always enable leader election

### DIFF
--- a/charts/multicluster-scheduler/templates/cm.yaml
+++ b/charts/multicluster-scheduler/templates/cm.yaml
@@ -8,13 +8,10 @@ data:
     apiVersion: kubescheduler.config.k8s.io/v1alpha2
     kind: KubeSchedulerConfiguration
     leaderElection:
-    {{- if gt .Values.scheduler.replicas 1 }}
       leaderElect: true
       resourceName: admiralty-proxy-scheduler
       resourceNamespace: {{ .Release.Namespace }}
-    {{- else }}
-      leaderElect: false
-    {{- end }}
+      resourceLock: leases
     profiles:
       - schedulerName: admiralty-proxy
         plugins:
@@ -34,14 +31,10 @@ data:
     apiVersion: kubescheduler.config.k8s.io/v1alpha2
     kind: KubeSchedulerConfiguration
     leaderElection:
-    {{- if gt .Values.scheduler.replicas 1 }}
       leaderElect: true
       resourceName: admiralty-candidate-scheduler
       resourceNamespace: {{ .Release.Namespace }}
       resourceLock: leases
-    {{- else }}
-      leaderElect: false
-    {{- end }}
     profiles:
       - schedulerName: admiralty-candidate
         plugins:

--- a/charts/multicluster-scheduler/templates/deploy.yaml
+++ b/charts/multicluster-scheduler/templates/deploy.yaml
@@ -45,6 +45,7 @@ spec:
             {{- with .Values.controllerManager.resources }}
           resources: {{ toYaml . | nindent 12 }}
             {{- end }}
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ include "fullname" . }}
       volumes:
         - name: cert
@@ -112,6 +113,7 @@ spec:
             {{- with .Values.scheduler.resources }}
           resources: {{ toYaml . | nindent 12 }}
             {{- end }}
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ include "fullname" . }}
       volumes:
         - name: config
@@ -178,6 +180,7 @@ spec:
             {{- with .Values.scheduler.resources }}
           resources: {{ toYaml . | nindent 12 }}
             {{- end }}
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ include "fullname" . }}
       volumes:
         - name: config
@@ -249,6 +252,7 @@ spec:
             {{- with .Values.restarter.resources }}
           resources: {{ toYaml . | nindent 12 }}
             {{- end }}
+      priorityClassName: system-cluster-critical
       serviceAccountName: {{ include "fullname" . }}
         {{- with .Values.imagePullSecretName }}
       imagePullSecrets:

--- a/charts/multicluster-scheduler/templates/deploy.yaml
+++ b/charts/multicluster-scheduler/templates/deploy.yaml
@@ -10,7 +10,7 @@ spec:
       component: controller-manager
   replicas: {{ .Values.controllerManager.replicas }}
   strategy:
-    type: {{ gt .Values.controllerManager.replicas 1 | ternary "RollingUpdate" "Recreate" }}
+    type: RollingUpdate
   template:
     metadata:
       labels: {{ include "labels" . | nindent 8 }}
@@ -18,16 +18,13 @@ spec:
     spec:
       containers:
         - name: controller-manager
-{{- if gt .Values.controllerManager.replicas 1 }}
           args: ["--leader-elect"]
-{{- end }}
           env:
-{{- if gt .Values.controllerManager.replicas 1 }}
+            # POD_NAME for leader election
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-{{- end }}
             - name: SOURCE_CLUSTER_ROLE_NAME
               value: {{ include "fullname" . }}-source
             - name: CLUSTER_SUMMARY_VIEWER_CLUSTER_ROLE_NAME
@@ -96,7 +93,7 @@ spec:
       component: proxy-scheduler
   replicas: {{ .Values.scheduler.replicas }}
   strategy:
-    type: {{ gt .Values.scheduler.replicas 1 | ternary "RollingUpdate" "Recreate" }}
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -162,7 +159,7 @@ spec:
       component: candidate-scheduler
   replicas: {{ .Values.scheduler.replicas }}
   strategy:
-    type: {{ gt .Values.scheduler.replicas 1 | ternary "RollingUpdate" "Recreate" }}
+    type: RollingUpdate
   template:
     metadata:
       annotations:
@@ -228,7 +225,7 @@ spec:
       component: restarter
   replicas: {{ .Values.scheduler.replicas }}
   strategy:
-    type: {{ gt .Values.restarter.replicas 1 | ternary "RollingUpdate" "Recreate" }}
+    type: RollingUpdate
   template:
     metadata:
       labels: {{ include "labels" . | nindent 8 }}
@@ -236,16 +233,13 @@ spec:
     spec:
       containers:
         - name: restarter
-{{- if gt .Values.restarter.replicas 1 }}
           args: ["--leader-elect"]
-{{- end }}
           env:
-{{- if gt .Values.controllerManager.replicas 1 }}
+            # POD_NAME for leader election
             - name: POD_NAME
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-{{- end }}
             - name: ADMIRALTY_CONTROLLER_MANAGER_DEPLOYMENT_NAME
               value: {{ include "fullname" . }}-controller-manager
             - name: ADMIRALTY_PROXY_SCHEDULER_DEPLOYMENT_NAME

--- a/charts/multicluster-scheduler/values.yaml
+++ b/charts/multicluster-scheduler/values.yaml
@@ -7,7 +7,7 @@ sourceController:
   enabled: true
 
 controllerManager:
-  replicas: 1
+  replicas: 2
   image:
     repository: "quay.io/admiralty/multicluster-scheduler-agent"
     tag: "" # (default: .Chart.AppVersion)
@@ -34,7 +34,7 @@ controllerManager:
   tolerations: []
 
 scheduler:
-  replicas: 1
+  replicas: 2
   image:
     repository: "quay.io/admiralty/multicluster-scheduler-scheduler"
     tag: "" # (default: .Chart.AppVersion)
@@ -87,7 +87,7 @@ postDeleteJob:
   tolerations: []
 
 restarter:
-  replicas: 1
+  replicas: 2
   image:
     repository: "quay.io/admiralty/multicluster-scheduler-restarter"
     tag: "" # (default: .Chart.AppVersion)


### PR DESCRIPTION
- so users starting with 1 replica per deployment can scale them out directly rather than via helm
- use 2 replicas by default so PDB isn't an issue
- (unrelated) use system-cluster-critical priority class to limit preemption and guarantee scheduling