### PR TITLE
exclude labels from aggregation on virtual nodes

### DIFF
--- a/pkg/apis/multicluster/v1alpha1/clustertarget_types.go
+++ b/pkg/apis/multicluster/v1alpha1/clustertarget_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Multicluster-Scheduler Authors.
+ * Copyright 2021 The Multicluster-Scheduler Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -42,6 +42,8 @@ type ClusterTargetSpec struct {
 	Self bool `json:"self,omitempty"`
 	// +optional
 	KubeconfigSecret *ClusterKubeconfigSecret `json:"kubeconfigSecret,omitempty"`
+	// +optional
+	ExcludedLabelsRegexp *string `json:"excludedLabelsRegexp,omitempty"`
 }
 
 type ClusterKubeconfigSecret struct {

--- a/pkg/apis/multicluster/v1alpha1/target_types.go
+++ b/pkg/apis/multicluster/v1alpha1/target_types.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Multicluster-Scheduler Authors.
+ * Copyright 2021 The Multicluster-Scheduler Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -41,6 +41,8 @@ type TargetSpec struct {
 	Self bool `json:"self,omitempty"`
 	// +optional
 	KubeconfigSecret *KubeconfigSecret `json:"kubeconfigSecret,omitempty"`
+	// +optional
+	ExcludedLabelsRegexp *string `json:"excludedLabelsRegexp,omitempty"`
 }
 
 type KubeconfigSecret struct {

--- a/pkg/apis/multicluster/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/multicluster/v1alpha1/zz_generated.deepcopy.go
@@ -281,6 +281,11 @@ func (in *ClusterTargetSpec) DeepCopyInto(out *ClusterTargetSpec) {
 		*out = new(ClusterKubeconfigSecret)
 		**out = **in
 	}
+	if in.ExcludedLabelsRegexp != nil {
+		in, out := &in.ExcludedLabelsRegexp, &out.ExcludedLabelsRegexp
+		*out = new(string)
+		**out = **in
+	}
 	return
 }
 
@@ -563,6 +568,11 @@ func (in *TargetSpec) DeepCopyInto(out *TargetSpec) {
 	if in.KubeconfigSecret != nil {
 		in, out := &in.KubeconfigSecret, &out.KubeconfigSecret
 		*out = new(KubeconfigSecret)
+		**out = **in
+	}
+	if in.ExcludedLabelsRegexp != nil {
+		in, out := &in.ExcludedLabelsRegexp, &out.ExcludedLabelsRegexp
+		*out = new(string)
 		**out = **in
 	}
 	return

--- a/pkg/config/agent/agent.go
+++ b/pkg/config/agent/agent.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Multicluster-Scheduler Authors.
+ * Copyright 2021 The Multicluster-Scheduler Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -38,10 +38,11 @@ type Config struct {
 }
 
 type Target struct {
-	Name         string
-	ClientConfig *rest.Config
-	Self         bool // optimization to re-use clients, informers, etc.
-	Namespace    string
+	Name                 string
+	ClientConfig         *rest.Config
+	Self                 bool // optimization to re-use clients, informers, etc.
+	Namespace            string
+	ExcludedLabelsRegexp *string
 }
 
 func (t Target) GetKey() string {
@@ -93,7 +94,13 @@ func addClusterTarget(ctx context.Context, k *kubernetes.Clientset, agentCfg *Co
 		cfg = config.GetConfigOrDie()
 	}
 
-	c := Target{Name: t.Name, ClientConfig: cfg, Namespace: corev1.NamespaceAll, Self: t.Spec.Self}
+	c := Target{
+		Name:                 t.Name,
+		ClientConfig:         cfg,
+		Namespace:            corev1.NamespaceAll,
+		Self:                 t.Spec.Self,
+		ExcludedLabelsRegexp: t.Spec.ExcludedLabelsRegexp,
+	}
 	agentCfg.Targets = append(agentCfg.Targets, c)
 }
 
@@ -115,7 +122,13 @@ func addTarget(ctx context.Context, k *kubernetes.Clientset, agentCfg *Config, t
 		cfg = config.GetConfigOrDie()
 	}
 
-	c := Target{Name: t.Name, ClientConfig: cfg, Namespace: t.Namespace, Self: t.Spec.Self}
+	c := Target{
+		Name:                 t.Name,
+		ClientConfig:         cfg,
+		Namespace:            t.Namespace,
+		Self:                 t.Spec.Self,
+		ExcludedLabelsRegexp: t.Spec.ExcludedLabelsRegexp,
+	}
 	agentCfg.Targets = append(agentCfg.Targets, c)
 }
 

--- a/pkg/controllers/resources/upstream_test.go
+++ b/pkg/controllers/resources/upstream_test.go
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 The Multicluster-Scheduler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package resources
+
+import (
+	"regexp"
+	"testing"
+
+	"admiralty.io/multicluster-scheduler/pkg/model/virtualnode"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_upstream_reconcileLabels(t *testing.T) {
+	targetName := "targetName"
+	clusterSummaryLabels := map[string]string{"k1": "v1", "k2": "v2", "prefix.io/k1": "v1"}
+	addBaseLabels := func(m map[string]string) map[string]string {
+		l := virtualnode.BaseLabels()
+		for k, v := range m {
+			l[k] = v
+		}
+		return l
+	}
+	tests := []struct {
+		name                 string
+		excludedLabelsRegexp *regexp.Regexp
+		want                 map[string]string
+	}{{
+		name:                 "no exclusions",
+		excludedLabelsRegexp: nil,
+		want:                 addBaseLabels(map[string]string{"k1": "v1", "k2": "v2", "prefix.io/k1": "v1"}),
+	}, {
+		name:                 "exclude exact aggregated key",
+		excludedLabelsRegexp: regexp.MustCompile(`^k1=`),
+		want:                 addBaseLabels(map[string]string{"k2": "v2", "prefix.io/k1": "v1"}),
+	}, {
+		name:                 "exclude aggregated key suffix",
+		excludedLabelsRegexp: regexp.MustCompile(`k1=`),
+		want:                 addBaseLabels(map[string]string{"k2": "v2"}),
+	}, {
+		name:                 "exclude exact aggregated prefix",
+		excludedLabelsRegexp: regexp.MustCompile(`^prefix\.io/`),
+		want:                 addBaseLabels(map[string]string{"k1": "v1", "k2": "v2"}),
+	}, {
+		name:                 "exclude exact aggregated key-value pair",
+		excludedLabelsRegexp: regexp.MustCompile(`^k1=v1$`),
+		want:                 addBaseLabels(map[string]string{"k2": "v2", "prefix.io/k1": "v1"}),
+	}, {
+		name:                 "exclude two keys",
+		excludedLabelsRegexp: regexp.MustCompile(`^k1=|^k2=`),
+		want:                 addBaseLabels(map[string]string{"prefix.io/k1": "v1"}),
+	}}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := upstream{
+				excludedLabelsRegexp: map[string]*regexp.Regexp{targetName: tt.excludedLabelsRegexp},
+			}
+			got := r.reconcileLabels(targetName, clusterSummaryLabels)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/test/e2e/e2e.sh
+++ b/test/e2e/e2e.sh
@@ -26,6 +26,7 @@ source test/e2e/follow/test.sh
 source test/e2e/logs/test.sh
 source test/e2e/exec/test.sh
 source test/e2e/ingress/test.sh
+source test/e2e/virtual-node-labels/test.sh
 source test/e2e/webhook_ready.sh
 source test/e2e/no-rogue-finalizer/test.sh
 
@@ -70,6 +71,7 @@ follow_test 1 2
 logs_test 1 2
 exec_test 1 2
 ingress_test 1 2
+virtual-node-labels_test 1 2
 no-rogue-finalizer_test
 
 echo "ALL SUCCEEDED"

--- a/test/e2e/virtual-node-labels/test.sh
+++ b/test/e2e/virtual-node-labels/test.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright 2021 The Multicluster-Scheduler Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -euo pipefail
+
+source test/e2e/aliases.sh
+
+virtual-node-labels_test() {
+  i=$1
+  j=$2
+
+  k $j label node --all kubernetes.azure.com/cluster=cluster$j --overwrite
+  while [[ "$(k $i get node admiralty-default-c$j -o json | jq -r '.metadata.labels["kubernetes.azure.com/cluster"]')" != cluster$j ]]; do sleep 1; done
+  k $i patch target c$j --type=merge -p '{"spec":{"excludedLabelsRegexp": "^kubernetes\\.azure\\.com/cluster="}}'
+  while [[ "$(k $i get node admiralty-default-c$j -o json | jq -r '.metadata.labels["kubernetes.azure.com/cluster"]')" == cluster$j ]]; do sleep 1; done
+  k $i patch target c$j --type=merge -p '{"spec":{"excludedLabelsRegexp": null}}'
+  k $j label node --all kubernetes.azure.com/cluster-
+}
+
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+  virtual-node-labels_test "${@}"
+fi


### PR DESCRIPTION
via regexp configured on targets, matching labels formatted as key=value

see unit tests for examples

TODO: proper user documentation

fixes #114 with the following (Cluster)Target patch:

```yaml
spec:
  excludedLabelsRegexp: ^kubernetes\.azure\.com/cluster=
```