### PR TITLE
refactor controllers from fan-out to 1-on-1

### DIFF
--- a/pkg/controllers/resources/upstream_test.go
+++ b/pkg/controllers/resources/upstream_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 func Test_upstream_reconcileLabels(t *testing.T) {
-	targetName := "targetName"
 	clusterSummaryLabels := map[string]string{"k1": "v1", "k2": "v2", "prefix.io/k1": "v1"}
 	addBaseLabels := func(m map[string]string) map[string]string {
 		l := virtualnode.BaseLabels()
@@ -66,9 +65,9 @@ func Test_upstream_reconcileLabels(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			r := upstream{
-				excludedLabelsRegexp: map[string]*regexp.Regexp{targetName: tt.excludedLabelsRegexp},
+				excludedLabelsRegexp: tt.excludedLabelsRegexp,
 			}
-			got := r.reconcileLabels(targetName, clusterSummaryLabels)
+			got := r.reconcileLabels(clusterSummaryLabels)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/webhooks/proxypod/proxypod.go
+++ b/pkg/webhooks/proxypod/proxypod.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Multicluster-Scheduler Authors.
+ * Copyright 2021 The Multicluster-Scheduler Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -147,19 +147,6 @@ func (m mutator) mutate(pod *corev1.Pod) error {
 	// with a finalizer until its delegate is fully deleted
 	var grace int64 = 0
 	pod.Spec.TerminationGracePeriodSeconds = &grace
-
-	// add finalizer because we can't add it when we create delegates in proxy scheduler
-	// (pod updates confuse the scheduler)
-	hasFinalizer := false
-	for _, f := range pod.Finalizers {
-		if f == common.CrossClusterGarbageCollectionFinalizer {
-			hasFinalizer = true
-			break
-		}
-	}
-	if !hasFinalizer {
-		pod.Finalizers = append(pod.Finalizers, common.CrossClusterGarbageCollectionFinalizer)
-	}
 
 	// add label for post-delete hook to remove finalizers
 	if pod.Labels == nil {

--- a/pkg/webhooks/proxypod/proxypod_test.go
+++ b/pkg/webhooks/proxypod/proxypod_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 The Multicluster-Scheduler Authors.
+ * Copyright 2021 The Multicluster-Scheduler Authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,7 +54,6 @@ var testCases = map[string]struct {
 				Labels: map[string]string{
 					common.LabelKeyHasFinalizer: "true",
 				},
-				Finalizers: []string{common.CrossClusterGarbageCollectionFinalizer},
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector: map[string]string{
@@ -114,8 +113,7 @@ var testCases = map[string]struct {
 					common.AnnotationKeySourcePodManifest: "HACK", // yaml serialization computed in test code
 					"k1":                                  "v1",
 				},
-				Labels:     map[string]string{"k2": "v2", common.LabelKeyHasFinalizer: "true"},
-				Finalizers: []string{common.CrossClusterGarbageCollectionFinalizer},
+				Labels: map[string]string{"k2": "v2", common.LabelKeyHasFinalizer: "true"},
 			},
 			Spec: corev1.PodSpec{
 				NodeSelector: map[string]string{


### PR DESCRIPTION
The problem with fan-out controllers was that they wouldn't start if one target was unavailable (blocked at WaitForCacheSync, and we'd rather sync the cache before reconciling).

Another benefit is the use of more namespaced informers (safer, faster).

Note: this reopens a rare race condition where candidates can be orphaned if proxy pods are deleted before finalizers are added (they can't be added before because that would invalidate the proxy scheduler cache mid-cycle). This is a trade-off. We will eventually need proper GC and let go of finalizers and their many flaws.

fixes #106 