### PR TITLE
add resource quota in release namespace for system-cluster-critical

### DIFF
--- a/charts/multicluster-scheduler/templates/quota.yaml
+++ b/charts/multicluster-scheduler/templates/quota.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ include "fullname" . }}
+spec:
+  scopeSelector:
+    matchExpressions:
+    - operator: In
+      scopeName: PriorityClass
+      values:
+      - system-cluster-critical


### PR DESCRIPTION
priority class which is used by Admiralty pods

because GKE (and possibly other distributions) limits this priority class's consumption by default using https://kubernetes.io/docs/concepts/policy/resource-quotas/#limit-priority-class-consumption-by-default

fixes #124 