### PR TITLE
upgrade PodDisruptionBudgets to policy/v1

### DIFF
--- a/charts/multicluster-scheduler/templates/deploy.yaml
+++ b/charts/multicluster-scheduler/templates/deploy.yaml
@@ -69,7 +69,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
         {{- end }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-controller-manager
@@ -134,7 +134,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
         {{- end }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-proxy-scheduler
@@ -199,7 +199,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
         {{- end }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-candidate-scheduler
@@ -265,7 +265,7 @@ spec:
       tolerations: {{ toYaml . | nindent 8 }}
         {{- end }}
 ---
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "fullname" . }}-restarter


### PR DESCRIPTION
policy/v1 was introduced in 1.21, which is our minimum requirement now

policy/v1beta1 will be dropped in 1.25, so upgrading ensures we'll support 1.25 (unless something else breaks)

Signed-off-by: adrienjt <adrienjt@users.noreply.github.com>