### PR TITLE
patch for #156 https://github.com/admiraltyio/admiralty/issues/156

### DIFF
--- a/pkg/model/virtualnode/model.go
+++ b/pkg/model/virtualnode/model.go
@@ -26,6 +26,7 @@ func BaseLabels(targetNamespace, targetName string) map[string]string {
 		common.LabelAndTaintKeyVirtualKubeletProvider:             common.VirtualKubeletProviderName,
 		"kubernetes.io/role":                                      "cluster",
 		"alpha.service-controller.kubernetes.io/exclude-balancer": "true",
+		"node.kubernetes.io/exclude-from-external-load-balancers": "true",
 	}
 	if targetNamespace == "" {
 		l[common.LabelKeyClusterTargetName] = targetName


### PR DESCRIPTION
This change adds the label adopted in Kubernetes 1.16 and keeps the legacy label that was deprecated.

Signed-off-by: Byran Carlock <bcarlock@emergemarket.com>