### PR TITLE
change wait.ErrWaitTimeout method to wait.Interrupted() as wait.ErrWaitTimeout was deprecated

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -325,7 +325,7 @@ func startVirtualKubeletServers(ctx context.Context, agentCfg agentconfig.Config
 	}
 
 	certPEM, keyPEM, err := csr.GetCertificateFromKubernetesAPIServer(ctx, k)
-	if err == wait.ErrWaitTimeout {
+	if wait.Interrupted(err) {
 		utilruntime.HandleError(fmt.Errorf("timed out waiting for virtual kubelet serving certificate to be signed, pod logs/exec won't be supported"))
 		return
 	}


### PR DESCRIPTION
https://github.com/admiraltyio/admiralty/blob/1c8f37843e3bf1505de1a68ee518739c1c49d956/cmd/agent/main.go#L328