### PR TITLE
fix(proxy scheduler): exit filter step early when scheduling gates are found

### DIFF
--- a/pkg/scheduler_plugins/proxy/plugin.go
+++ b/pkg/scheduler_plugins/proxy/plugin.go
@@ -146,13 +146,7 @@ func (pl *Plugin) Filter(ctx context.Context, state *framework.CycleState, pod *
 			return false, nil
 		}
 		_, isReserved = c.Annotations[common.AnnotationKeyIsReserved]
-
-		for _, cond := range c.Status.Conditions {
-			if cond.Type == v1.PodScheduled && cond.Status == v1.ConditionFalse && cond.Reason == v1.PodReasonUnschedulable {
-				isUnschedulable = true
-				break
-			}
-		}
+		isUnschedulable = isCandidatePodUnschedulable(c)
 
 		klog.V(1).Infof("candidate %s is reserved? %v unschedulable? %v", c.Name, isReserved, isUnschedulable)
 

--- a/pkg/scheduler_plugins/proxy/utils.go
+++ b/pkg/scheduler_plugins/proxy/utils.go
@@ -1,0 +1,32 @@
+/*
+ * Copyright The Multicluster-Scheduler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	v1 "k8s.io/api/core/v1"
+
+	"admiralty.io/multicluster-scheduler/pkg/apis/multicluster/v1alpha1"
+)
+
+func isCandidatePodUnschedulable(c *v1alpha1.PodChaperon) bool {
+	for _, cond := range c.Status.Conditions {
+		if cond.Type == v1.PodScheduled && cond.Status == v1.ConditionFalse && (cond.Reason == v1.PodReasonUnschedulable || cond.Reason == v1.PodReasonSchedulingGated) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/scheduler_plugins/proxy/utils_test.go
+++ b/pkg/scheduler_plugins/proxy/utils_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright The Multicluster-Scheduler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package proxy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+
+	"admiralty.io/multicluster-scheduler/pkg/apis/multicluster/v1alpha1"
+)
+
+func TestIsPodUnschedulable(t *testing.T) {
+	tests := []struct {
+		name            string
+		conditionStatus []v1.PodCondition
+		want            bool
+	}{
+		{
+			name:            "reason pod unschedulable",
+			conditionStatus: []v1.PodCondition{{Status: v1.ConditionFalse, Type: v1.PodScheduled, Reason: v1.PodReasonUnschedulable}},
+			want:            true,
+		},
+		{
+			name:            "scheduling gated",
+			conditionStatus: []v1.PodCondition{{Status: v1.ConditionFalse, Type: v1.PodScheduled, Reason: v1.PodReasonSchedulingGated}},
+			want:            true,
+		},
+		{
+			name:            "pod scheduled",
+			conditionStatus: []v1.PodCondition{{Status: v1.ConditionTrue, Type: v1.PodScheduled}},
+			want:            false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podChaperon := &v1alpha1.PodChaperon{
+				Status: v1.PodStatus{Conditions: tt.conditionStatus},
+			}
+			res := isCandidatePodUnschedulable(podChaperon)
+			require.Equal(t, tt.want, res)
+		})
+	}
+}


### PR DESCRIPTION
### Motivation

We use admiralty alongside Kueue for scheduling plain pod workloads on the target clusters. For plain pod management, Kueue utilizes [scheduling gates](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-scheduling-readiness/) to block the scheduling cycle from running. The scheduling gate remains on the pod until Kueue admits the pod when quota is available. Pods that are scheduling gated don't have the `PodReasonUnschedulable` as the condition reason and therefore, may cause unnecessary delays in the filter step since it polls for the entirety of the 30 seconds waiting for `PodReasonUnschedulable`.

This fixes this logic to consider pods with scheduling gates as unschedulable.