### PR TITLE
feat: allow labels to be copied to delegate pods without prefix

### DIFF
--- a/docs/user_guide/pod_configuration.md
+++ b/docs/user_guide/pod_configuration.md
@@ -1,0 +1,19 @@
+---
+title: Pod Configuration
+custom_edit_url: https://github.com/admiraltyio/admiralty/edit/master/docs/user_guide/pod_configuration.md
+---
+
+
+## Label Prefixing
+Admiralty appends a prefix to the delegate pod labels `multicluster.admiralty.io/` in the target clusters. This behavior
+can be overridden per pod through the `multicluster.admiralty.io/no-prefix-label-regexp` annotation. This is useful to 
+support components that have functionality that relies on pod labels. For example, webhooks or monitoring resources.
+
+
+:::tip
+One use-case is to prevent prefixing the Kueue queue name label. This can be achieved through:
+```
+multicluster.admiralty.io/no-prefix-label-regexp="^kueue\.x-k8s\.io\/queue-name"
+```
+:::
+

--- a/docs/user_guide/pod_configuration.md
+++ b/docs/user_guide/pod_configuration.md
@@ -5,7 +5,7 @@ custom_edit_url: https://github.com/admiraltyio/admiralty/edit/master/docs/user_
 
 
 ## Label Prefixing
-Admiralty appends a prefix to the delegate pod labels `multicluster.admiralty.io/` in the target clusters. This behavior
+Admiralty prefixes delegate pod labels with `multicluster.admiralty.io/` in the target clusters. This behavior is useful in bursting cluster topologies, where the source cluster is also a target cluster, so as not to confuse controllers of proxy pods, e.g., replicasets. The behavior
 can be overridden per pod through the `multicluster.admiralty.io/no-prefix-label-regexp` annotation. This is useful to 
 support components that have functionality that relies on pod labels. For example, webhooks or monitoring resources.
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -40,9 +40,9 @@ var (
 
 	AnnotationKeyUseConstraintsFromSpecForProxyPodScheduling = KeyPrefix + "use-constraints-from-spec-for-proxy-pod-scheduling"
 
-	// AnnotationKeyDelegateLabelKeysToSkipPrefixing defines label keys that won't get prefixed with KeyPrefix
-	// on the delegate pod and retain the original label key
-	AnnotationKeyDelegateLabelKeysToSkipPrefixing = KeyPrefix + "label-keys-to-skip-prefixing"
+	// AnnotationNoPrefixLabelRegexp defines a regex that when matched on labels, the label
+	// gets copied as-is to the delegate pod without appending KeyPrefix prefix
+	AnnotationNoPrefixLabelRegexp = KeyPrefix + "no-prefix-label-regexp"
 
 	// annotations on proxy pods (by mutating admission webhook)
 

--- a/pkg/common/constants.go
+++ b/pkg/common/constants.go
@@ -40,6 +40,10 @@ var (
 
 	AnnotationKeyUseConstraintsFromSpecForProxyPodScheduling = KeyPrefix + "use-constraints-from-spec-for-proxy-pod-scheduling"
 
+	// AnnotationKeyDelegateLabelKeysToSkipPrefixing defines label keys that won't get prefixed with KeyPrefix
+	// on the delegate pod and retain the original label key
+	AnnotationKeyDelegateLabelKeysToSkipPrefixing = KeyPrefix + "label-keys-to-skip-prefixing"
+
 	// annotations on proxy pods (by mutating admission webhook)
 
 	KeyPrefixSourcePod = KeyPrefix + "sourcepod-"

--- a/pkg/controllers/follow/service/controller.go
+++ b/pkg/controllers/follow/service/controller.go
@@ -181,7 +181,10 @@ func (r reconciler) Handle(obj interface{}) (requeueAfter *time.Duration, err er
 			svcCopy.Annotations[common.AnnotationKeyOriginalSelector] = originalSelector
 		}
 		if r.serviceRerouteEnabled {
-			selector, changed := delegatepod.ChangeLabels(svcCopy.Spec.Selector, svc.Annotations[common.AnnotationKeyDelegateLabelKeysToSkipPrefixing])
+			selector, changed, err := delegatepod.ChangeLabels(svcCopy.Spec.Selector, svc.Annotations[common.AnnotationNoPrefixLabelRegexp])
+			if err != nil {
+				return nil, fmt.Errorf("failed to change labels for mirrored service %s: %v", svcCopy.Name, err)
+			}
 			if changed {
 				needUpdateLocal = true
 				svcCopy.Spec.Selector = selector

--- a/pkg/controllers/follow/service/controller.go
+++ b/pkg/controllers/follow/service/controller.go
@@ -181,7 +181,7 @@ func (r reconciler) Handle(obj interface{}) (requeueAfter *time.Duration, err er
 			svcCopy.Annotations[common.AnnotationKeyOriginalSelector] = originalSelector
 		}
 		if r.serviceRerouteEnabled {
-			selector, changed := delegatepod.ChangeLabels(svcCopy.Spec.Selector)
+			selector, changed := delegatepod.ChangeLabels(svcCopy.Spec.Selector, svc.Annotations[common.AnnotationKeyDelegateLabelKeysToSkipPrefixing])
 			if changed {
 				needUpdateLocal = true
 				svcCopy.Spec.Selector = selector

--- a/pkg/model/delegatepod/model.go
+++ b/pkg/model/delegatepod/model.go
@@ -17,7 +17,8 @@
 package delegatepod
 
 import (
-	"slices"
+	"fmt"
+	"regexp"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -49,8 +50,10 @@ func MakeDelegatePod(proxyPod *corev1.Pod, clusterName string) (*v1alpha1.PodCha
 		}
 	}
 
-	labels, _ := ChangeLabels(srcPod.Labels, srcPod.Annotations[common.AnnotationKeyDelegateLabelKeysToSkipPrefixing])
-
+	labels, _, err := ChangeLabels(srcPod.Labels, srcPod.Annotations[common.AnnotationNoPrefixLabelRegexp])
+	if err != nil {
+		return nil, fmt.Errorf("failed to change labels for proxy pod %s: %v", proxyPod.Name, err)
+	}
 	delegatePod := &v1alpha1.PodChaperon{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace:    proxyPod.Namespace, // already defaults to "default" (vs. could be empty in srcPod)
@@ -91,14 +94,17 @@ func MakeDelegatePod(proxyPod *corev1.Pod, clusterName string) (*v1alpha1.PodCha
 // The name segment is required and must be 63 characters or less"
 // https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
 // TODO: resolve conflict two keys have same name but different prefixes
-func ChangeLabels(labels map[string]string, labelKeysToSkipPrefixing string) (map[string]string, bool) {
+func ChangeLabels(labels map[string]string, noPrefixLabelRegex string) (map[string]string, bool, error) {
 	changed := false
 	newLabels := make(map[string]string)
-	labelKeysToSkip := strings.Split(labelKeysToSkipPrefixing, ",")
+	re, err := regexp.Compile(noPrefixLabelRegex)
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to complie regexp %s: %v", noPrefixLabelRegex, err)
+	}
 
 	for k, v := range labels {
 		keySplit := strings.Split(k, "/") // note: assume no empty key (enforced by Kubernetes)
-		if slices.Contains(labelKeysToSkip, k) {
+		if len(noPrefixLabelRegex) > 0 && re.MatchString(fmt.Sprintf("%s=%s", k, v)) {
 			newLabels[k] = v
 			continue
 		}
@@ -110,7 +116,7 @@ func ChangeLabels(labels map[string]string, labelKeysToSkipPrefixing string) (ma
 			newLabels[k] = v
 		}
 	}
-	return newLabels, changed
+	return newLabels, changed, nil
 }
 
 func removeServiceAccount(podSpec *corev1.PodSpec) {

--- a/pkg/model/delegatepod/model_test.go
+++ b/pkg/model/delegatepod/model_test.go
@@ -1,0 +1,71 @@
+/*
+ * Copyright The Multicluster-Scheduler Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package delegatepod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangeLabels(t *testing.T) {
+	tests := []struct {
+		name                     string
+		inputLabels              map[string]string
+		labelKeysToSkipPrefixing string
+		outputLabels             map[string]string
+	}{
+		{
+			name: "mix of domains, no skip",
+			inputLabels: map[string]string{
+				"foo.com/bar":                   "a",
+				"baz.com/foo":                   "b",
+				"multicluster.admiralty.io/baz": "c",
+				"a":                             "d",
+			},
+			labelKeysToSkipPrefixing: "",
+			outputLabels: map[string]string{
+				"multicluster.admiralty.io/bar": "a",
+				"multicluster.admiralty.io/foo": "b",
+				"multicluster.admiralty.io/baz": "c",
+				"multicluster.admiralty.io/a":   "d",
+			},
+		},
+		{
+			name: "skip multiple domains",
+			inputLabels: map[string]string{
+				"foo.com/bar":                   "a",
+				"baz.com/foo":                   "b",
+				"multicluster.admiralty.io/foo": "c",
+				"a":                             "d",
+			},
+			labelKeysToSkipPrefixing: "foo.com/bar,baz.com/foo",
+			outputLabels: map[string]string{
+				"foo.com/bar":                   "a",
+				"baz.com/foo":                   "b",
+				"multicluster.admiralty.io/foo": "c",
+				"multicluster.admiralty.io/a":   "d",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out, _ := ChangeLabels(tt.inputLabels, tt.labelKeysToSkipPrefixing)
+			require.Equal(t, tt.outputLabels, out)
+		})
+	}
+}


### PR DESCRIPTION
This allows specifying an annotation in a similar fashion to `use-constraints-from-spec-for-proxy-pod-scheduling` that would allow labels to be copied as is from the proxy pod to the delegate pod without replacing the label key domain with `multicluster.admiralty.io/`. 

The motivation behind this is to enable a multicluster Kueue setup through admiralty. In that setup, admission is gated by ClusterQueues in target clusters. Kueue only operates on pods labeled with `kueue.x-k8s.io/queue-name` and having admiralty prefix this with `multicluster.admiralty.io/` would break this interaction.
