### PR TITLE
build: add missing replace directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -198,3 +198,5 @@ replace k8s.io/controller-manager => k8s.io/controller-manager v0.30.5
 replace k8s.io/mount-utils => k8s.io/mount-utils v0.30.5
 
 replace k8s.io/pod-security-admission => k8s.io/pod-security-admission v0.30.5
+
+replace k8s.io/endpointslice => k8s.io/endpointslice v0.30.5


### PR DESCRIPTION
Adds a missing replace directive to satisfy commands used by IDEs (e.g. GoLand) for indexing the workspace:

the call to 
```
go list -json -m -u -mod=readonly all
```

would fail prior to this.